### PR TITLE
design: 필터 설정 페이지 - 지역 설정 단계 추가 퍼블리싱

### DIFF
--- a/src/app/chat/filter/page.tsx
+++ b/src/app/chat/filter/page.tsx
@@ -21,12 +21,12 @@ const Page = () => {
 
   return (
     <div className="min-h-screen">
-      <Header bgColorClassName="bg-gray-100">
+      <Header>
         <Header.Prev onPrevClick={prevStep} />
         <Header.Title>필터 설정하기</Header.Title>
         <Header.Close onCloseClick={() => router.push("/")} />
       </Header>
-      <main className="relative min-h-screen pt-16">
+      <main className="relative min-h-screen bg-white pt-16">
         <ProgressBar currentStep={currentStep} />
 
         <div className="px-5 pt-10">

--- a/src/components/common/FilterOptionCard.tsx
+++ b/src/components/common/FilterOptionCard.tsx
@@ -1,14 +1,14 @@
 import clsx from "clsx";
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 
-interface SelectCardProps {
+interface FilterOptionCardProps {
   option: string;
   selectedCards: string[];
   setSelectedCards: (option: string[]) => void;
 }
 
-const SelectCard = ({ option, selectedCards, setSelectedCards }: SelectCardProps) => {
+const FilterOptionCard = ({ option, selectedCards, setSelectedCards }: FilterOptionCardProps) => {
   const isSelected = selectedCards.includes(option);
 
   return (
@@ -22,7 +22,7 @@ const SelectCard = ({ option, selectedCards, setSelectedCards }: SelectCardProps
         )
       }
       className={clsx(
-        "shadow-selectCard relative flex h-16 items-center justify-start rounded-[8px] pl-5 pr-4 text-subtitle1",
+        "relative flex h-16 items-center justify-start rounded-[8px] pl-5 pr-4 text-subtitle1 shadow-selectCard",
         isSelected ? "bg-blue-100" : "bg-white",
       )}
     >
@@ -39,4 +39,4 @@ const SelectCard = ({ option, selectedCards, setSelectedCards }: SelectCardProps
   );
 };
 
-export default SelectCard;
+export default FilterOptionCard;

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -79,24 +79,36 @@ const LocationStep = ({ onNext }: LocationStepProps) => {
       {searchKeyword && (
         <div className="flex flex-col gap-4">
           <div className="text-body2 text-gray-800">검색결과 ({filteredData.length})</div>
-          <ul className="flex h-[calc(100vh-342px)] flex-col overflow-y-auto">
-            {filteredData.map((item, idx) => {
-              const isSelected = selectedLocation === item.id;
+          <div className="h-[calc(100vh-342px)] overflow-y-auto">
+            {filteredData.length > 0 ? (
+              <ul className="flex flex-col">
+                {filteredData.map((item, idx) => {
+                  const isSelected = selectedLocation === item.id;
 
-              return (
-                <li
-                  key={idx}
-                  onClick={() => setSelectedLocation(item.id)}
-                  className={`cursor-pointer border-b-[0.5px] border-gray-200 px-5 py-[10px] transition-colors ${
-                    isSelected ? "bg-gray-100" : "bg-white"
-                  }`}
-                >
-                  <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>
-                  <div className="text-body2">{item.detail}</div>
-                </li>
-              );
-            })}
-          </ul>
+                  return (
+                    <li
+                      key={idx}
+                      onClick={() => setSelectedLocation(item.id)}
+                      className={`cursor-pointer border-b-[0.5px] border-gray-200 px-5 py-[10px] transition-colors ${
+                        isSelected ? "bg-gray-100" : "bg-white"
+                      }`}
+                    >
+                      <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>
+                      <div className="text-body2">{item.detail}</div>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-2 whitespace-nowrap text-center">
+                <h1 className="text-subtitle1">원하는 검색 결과가 없으신가요?</h1>
+                <p className="text-body2 text-gray-700">
+                  철자나 띄어쓰기를 확인하거나, <br />
+                  인근 지역으로 검색해보세요!
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -23,7 +23,7 @@ const dummyData = [
 
 const LocationStep = ({ onNext }: LocationStepProps) => {
   const [input, setInput] = useState("");
-  const [searchKeyword, setSearchKeyword] = useState("이수");
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   const handleSearch = () => {
     if (input.trim()) {

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import SearchIcon from "../../../public/icons/search.svg";
 import Image from "next/image";
@@ -25,6 +25,10 @@ const LocationStep = ({ onNext }: LocationStepProps) => {
   const [input, setInput] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
   const [selectedLocation, setSelectedLocation] = useState("");
+
+  useEffect(() => {
+    setSelectedLocation("");
+  }, [searchKeyword]);
 
   const handleSearch = () => {
     if (input.trim()) {

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -23,7 +23,7 @@ const dummyData = [
 
 const LocationStep = ({ onNext }: LocationStepProps) => {
   const [input, setInput] = useState("");
-  const [searchKeyword, setSearchKeyword] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("이수");
 
   const handleSearch = () => {
     if (input.trim()) {
@@ -76,9 +76,9 @@ const LocationStep = ({ onNext }: LocationStepProps) => {
         />
       </div>
       {searchKeyword && (
-        <div className="flex flex-col gap-4 overflow-hidden">
+        <div className="flex flex-col gap-4">
           <div className="text-body2 text-gray-800">검색결과 ({filteredData.length})</div>
-          <ul className="flex h-[270px] flex-col gap-[6px] overflow-y-auto">
+          <ul className="flex h-[calc(100vh-342px)] flex-col gap-[6px] overflow-y-auto">
             {filteredData.map((item, idx) => (
               <li key={idx} className="border-b-[0.5px] border-gray-200 py-[10px]">
                 <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -9,21 +9,22 @@ interface LocationStepProps {
 
 // 임시
 const dummyData = [
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-2" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 104-2" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-2" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 108-2" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
-  { title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "1", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-2" },
+  { id: "2", title: "이수역 7호선", detail: "서울 동작구 동작대로 104-2" },
+  { id: "3", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-2" },
+  { id: "4", title: "이수역 7호선", detail: "서울 동작구 동작대로 108-2" },
+  { id: "5", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "6", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "7", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "8", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "9", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
+  { id: "10", title: "이수역 7호선", detail: "서울 동작구 동작대로 105-1" },
 ];
 
 const LocationStep = ({ onNext }: LocationStepProps) => {
   const [input, setInput] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [selectedLocation, setSelectedLocation] = useState("");
 
   const handleSearch = () => {
     if (input.trim()) {
@@ -78,19 +79,29 @@ const LocationStep = ({ onNext }: LocationStepProps) => {
       {searchKeyword && (
         <div className="flex flex-col gap-4">
           <div className="text-body2 text-gray-800">검색결과 ({filteredData.length})</div>
-          <ul className="flex h-[calc(100vh-342px)] flex-col gap-[6px] overflow-y-auto">
-            {filteredData.map((item, idx) => (
-              <li key={idx} className="border-b-[0.5px] border-gray-200 py-[10px]">
-                <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>
-                <div className="text-body2">{item.detail}</div>
-              </li>
-            ))}
+          <ul className="flex h-[calc(100vh-342px)] flex-col overflow-y-auto">
+            {filteredData.map((item, idx) => {
+              const isSelected = selectedLocation === item.id;
+
+              return (
+                <li
+                  key={idx}
+                  onClick={() => setSelectedLocation(item.id)}
+                  className={`cursor-pointer border-b-[0.5px] border-gray-200 px-5 py-[10px] transition-colors ${
+                    isSelected ? "bg-gray-100" : "bg-white"
+                  }`}
+                >
+                  <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>
+                  <div className="text-body2">{item.detail}</div>
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}
 
       <div className="absolute bottom-3 left-1/2 w-full -translate-x-1/2 transform px-5">
-        <Button onClick={onNext} disabled={input.length === 0}>
+        <Button onClick={onNext} disabled={selectedLocation === ""}>
           다음
         </Button>
       </div>

--- a/src/components/setup/LocationStep.tsx
+++ b/src/components/setup/LocationStep.tsx
@@ -80,7 +80,7 @@ const LocationStep = ({ onNext }: LocationStepProps) => {
           <div className="text-body2 text-gray-800">검색결과 ({filteredData.length})</div>
           <ul className="flex h-[270px] flex-col gap-[6px] overflow-y-auto">
             {filteredData.map((item, idx) => (
-              <li key={idx} className="py-[10px]">
+              <li key={idx} className="border-b-[0.5px] border-gray-200 py-[10px]">
                 <div className="text-body1">{highlightText(item.title, searchKeyword)}</div>
                 <div className="text-body2">{item.detail}</div>
               </li>

--- a/src/components/setup/OptionSelectStep.tsx
+++ b/src/components/setup/OptionSelectStep.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "../ui/button";
-import SelectCard from "../common/SelectCard";
+import FilterOptionCard from "../common/FilterOptionCard";
 
 interface OptionSelectStepProps {
   onNext: () => void;
@@ -18,7 +18,7 @@ const OptionSelectStep = ({ onNext, title, options }: OptionSelectStepProps) => 
         <div className="flex justify-end text-body2 text-gray-800">중복 선택 가능</div>
         <div className="flex flex-col gap-4">
           {options.map((option) => (
-            <SelectCard
+            <FilterOptionCard
               key={option}
               option={option}
               selectedCards={selectedOption}

--- a/src/components/setup/OptionSelectStep.tsx
+++ b/src/components/setup/OptionSelectStep.tsx
@@ -9,7 +9,7 @@ interface OptionSelectStepProps {
 }
 
 const OptionSelectStep = ({ onNext, title, options }: OptionSelectStepProps) => {
-  const [selected, setSelected] = useState<string[]>([]);
+  const [selectedOption, setSelectedOption] = useState<string[]>([]);
 
   return (
     <div className="flex h-full flex-col gap-5">
@@ -21,15 +21,15 @@ const OptionSelectStep = ({ onNext, title, options }: OptionSelectStepProps) => 
             <SelectCard
               key={option}
               option={option}
-              selected={selected}
-              setSelected={setSelected}
+              selectedCards={selectedOption}
+              setSelectedCards={setSelectedOption}
             />
           ))}
         </div>
       </div>
 
       <div className="absolute bottom-3 left-1/2 w-full -translate-x-1/2 transform px-5">
-        <Button onClick={onNext} disabled={selected.length === 0}>
+        <Button onClick={onNext} disabled={selectedOption.length === 0}>
           다음
         </Button>
       </div>


### PR DESCRIPTION
## ✨ Related Issues
- close #38

## 📝 Task Details

- 필터 설정 페이지 지역 설정 단계에서 추가/수정된 디자인을 반영하였습니다.
- 검색 결과 목록 내 각 item에 border bottom 속성을 추가했습니다.
- 검색 결과 목록 height가 최하단까지 꽉 찬 상태에서 스크롤이 되도록 동적으로 수정했습니다.[e4e0fe2](https://github.com/FC-DEV3-Final-Project/zoop-frontend/pull/49/commits/e4e0fe22a93eedd2278e5ec98da735b99dfd62cc)
- 검색 결과 목록 내 item 선택된 경우의 style을 반영했습니다. 이에 따라 item이 선택되어야만 다음 버튼이 활성화되도록 로직을 수정했습니다. [f8d698f](https://github.com/FC-DEV3-Final-Project/zoop-frontend/pull/49/commits/f8d698f6001791ffba948a42d9c81434ccb95538)
- 검색 결과가 없을 경우의 안내 텍스트를 추가했습니다.  [7d3c9d3](https://github.com/FC-DEV3-Final-Project/zoop-frontend/pull/49/commits/7d3c9d37867ed8236981442e649cce2303f86dea)
  <img src="https://github.com/user-attachments/assets/88feecf8-8dc8-4199-a255-e3cb94327da1" width="300" />


## 📂 References
![image](https://github.com/user-attachments/assets/6dbfafc7-2395-4dd4-935d-6407bcad0d72)
&rightarrow; 선택 전
![image](https://github.com/user-attachments/assets/790561cf-21d6-4e0d-822d-20d00633d30c)
&rightarrow; 아이템을 선택해야 `다음` 버튼이 활성화됩니다.

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
