### PR TITLE
feat: header 수정

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -10,12 +10,13 @@ import AlarmIcon from "../../public/icons/alram.svg";
 type HeaderRootProps = {
   children: React.ReactNode;
   bgColorClassName?: string;
+  size?: "sm" | "md";
 };
 
-const Root = ({ children, bgColorClassName = "bg-white" }: HeaderRootProps) => {
+const Root = ({ children, bgColorClassName = "bg-white", size = "sm" }: HeaderRootProps) => {
   return (
     <div
-      className={`fixed top-0 z-10 flex h-16 w-full max-w-[600px] items-center justify-between px-5 ${bgColorClassName}`}
+      className={`fixed top-0 z-10 flex w-full max-w-[600px] items-center justify-between px-5 ${bgColorClassName} ${size === "sm" ? "h-12" : "h-16"}`}
     >
       {children}
     </div>
@@ -29,13 +30,13 @@ const Prev = ({ onPrevClick }: { onPrevClick?: () => void }) => (
 );
 
 const Hamburger = ({ onHamburgerClick }: { onHamburgerClick?: () => void }) => (
-  <div onClick={onHamburgerClick} className="flex justify-center cursor-pointer">
+  <div onClick={onHamburgerClick} className="flex cursor-pointer justify-center">
     <Image src={HamburgerIcon} alt="메뉴" width={24} height={24} />
   </div>
 );
 
 const Title = ({ children }: { children: string }) => (
-  <h1 className="absolute -translate-x-1/2 left-1/2 text-subtitle2">{children}</h1>
+  <h1 className="absolute left-1/2 -translate-x-1/2 text-subtitle2">{children}</h1>
 );
 
 const Close = ({ onCloseClick }: { onCloseClick?: () => void }) => (

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -23,8 +23,14 @@ const Root = ({ children, bgColorClassName = "bg-white", size = "sm" }: HeaderRo
   );
 };
 
-const Prev = ({ onPrevClick }: { onPrevClick?: () => void }) => (
-  <button onClick={onPrevClick} className="flex justify-center">
+const Prev = ({
+  onPrevClick,
+  className = "",
+}: {
+  onPrevClick?: () => void;
+  className?: string;
+}) => (
+  <button onClick={onPrevClick} className={`flex justify-center ${className}`}>
     <Image src={ArrowLeftIcon} alt="뒤로가기" width={24} height={24} />
   </button>
 );
@@ -35,8 +41,8 @@ const Hamburger = ({ onHamburgerClick }: { onHamburgerClick?: () => void }) => (
   </div>
 );
 
-const Title = ({ children }: { children: string }) => (
-  <h1 className="absolute left-1/2 -translate-x-1/2 text-subtitle2">{children}</h1>
+const Title = ({ children, className = "" }: { children: string; className?: string }) => (
+  <h1 className={`absolute left-1/2 -translate-x-1/2 text-subtitle2 ${className}`}>{children}</h1>
 );
 
 const Close = ({ onCloseClick }: { onCloseClick?: () => void }) => (


### PR DESCRIPTION
## ✨ Related Issues
- close #[issue_number]

## 📝 Task Details

- header 컴포넌트의 height가 home에서는 64px이고, 나머지는 48px이더라고요! size 속성 추가하였고, 기본 값 sm (48px)으로 두어서 각 페이지 내에서 header height가 48px이라면 수정할 부분은 없습니다!
- 현경님 지도 부분에서 prev 버튼과 title에 className 추가로 줄 수 있도록 추가했습니다

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
