### PR TITLE
feat: <AuthGuard> 컴포넌트를 만들어 RootLayout에서 감싸서 로그인 여부 확인함

### DIFF
--- a/src/apis/login/getUserInfo.ts
+++ b/src/apis/login/getUserInfo.ts
@@ -1,9 +1,21 @@
 import axiosInstance from "../utils/axiosInstance";
+import { useUserInfoStore } from "@/stores/useUserInfoStore";
 
 export const getUserInfo = async () => {
   try {
     const response = await axiosInstance.get("/users/auth/me");
-    return response.data;
+    const data = response.data;
+
+    // ✅ Zustand 저장
+    const setUser = useUserInfoStore.getState().setUser;
+    setUser({
+      userId: data.userId,
+      email: data.email,
+      nickname: data.nickname,
+      profileImage: data.profileImage,
+    });
+
+    return data;
   } catch (error) {
     console.error("getUserInfo 에러:", error);
     throw error;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { MSWComponent } from "@/components/MSWComponent";
 import Script from "next/script";
 import Providers from "./providers";
 import { Toaster } from "react-hot-toast";
+import AuthGuard from "@/components/AuthGuard";
 
 const pretendard = localFont({
   src: "../../public/fonts/PretendardVariable.woff2",
@@ -48,21 +49,23 @@ export default function RootLayout({
             strategy="beforeInteractive"
           />
           <Providers>
-            {useMock ? <MSWComponent>{children}</MSWComponent> : children}
-            <Toaster
-              position="bottom-center"
-              containerStyle={{
-                bottom: "80px",
-                left: "50%",
-                transform: "translateX(-50%)",
-                width: "600px",
-                maxWidth: "90vw",
-                padding: 0, // 패딩은 여기서 제거하고 CSS에서 처리
-              }}
-              toastOptions={{
-                className: "custom-toast",
-              }}
-            />
+            <AuthGuard>
+              {useMock ? <MSWComponent>{children}</MSWComponent> : children}
+              <Toaster
+                position="bottom-center"
+                containerStyle={{
+                  bottom: "80px",
+                  left: "50%",
+                  transform: "translateX(-50%)",
+                  width: "600px",
+                  maxWidth: "90vw",
+                  padding: 0, // 패딩은 여기서 제거하고 CSS에서 처리
+                }}
+                toastOptions={{
+                  className: "custom-toast",
+                }}
+              />
+            </AuthGuard>
           </Providers>{" "}
         </div>
       </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
           <Header bgColorClassName="bg-white/0">
             <div className="w-6" />
             <Header.Title>ZOOP</Header.Title>
-            <Header.Close onCloseClick={() => alert("알림 클릭")} />
+            <div className="w-6" />
           </Header>
 
           <div className="flex h-screen w-full flex-col items-center justify-center bg-gradient-to-b from-[#EDF0FD] to-white px-5 pt-16">

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const AuthGuard = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("access_token");
+
+    const isLoginPage = location.pathname === "/login";
+
+    if (!token && !isLoginPage) {
+      router.replace("/login");
+    }
+
+    if (token && isLoginPage) {
+      router.replace("/"); // 로그인한 사용자가 로그인 페이지 들어올 경우 홈으로
+    }
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default AuthGuard;

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,36 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = localStorage.getItem("access_token");
+
     const isLoginPage = location.pathname === "/login";
 
     if (!token && !isLoginPage) {
       router.replace("/login");
-    } else if (token && isLoginPage) {
-      router.replace("/"); // 로그인한 사용자가 로그인 페이지 들어올 경우 홈으로
     }
 
-    const timeout = setTimeout(() => {
-      setLoading(false);
-    }, 100);
-
-    return () => clearTimeout(timeout);
+    if (token && isLoginPage) {
+      router.replace("/"); // 로그인한 사용자가 로그인 페이지 들어올 경우 홈으로
+    }
   }, []);
-
-  if (loading) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-4 border-blue-400 border-t-transparent" />
-      </div>
-    );
-  }
 
   return <>{children}</>;
 };

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,24 +1,36 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = localStorage.getItem("access_token");
-
     const isLoginPage = location.pathname === "/login";
 
     if (!token && !isLoginPage) {
       router.replace("/login");
-    }
-
-    if (token && isLoginPage) {
+    } else if (token && isLoginPage) {
       router.replace("/"); // 로그인한 사용자가 로그인 페이지 들어올 경우 홈으로
     }
+
+    const timeout = setTimeout(() => {
+      setLoading(false);
+    }, 100);
+
+    return () => clearTimeout(timeout);
   }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-blue-400 border-t-transparent" />
+      </div>
+    );
+  }
 
   return <>{children}</>;
 };

--- a/src/hooks/common/useAuthFromHash.ts
+++ b/src/hooks/common/useAuthFromHash.ts
@@ -38,5 +38,5 @@ export default function useAuthFromHash({
 
     // 해시 제거
     window.history.replaceState(null, "", window.location.pathname);
-  }, [redirectIfNicknameNeeded, router]);
+  }, []);
 }

--- a/src/hooks/common/useAuthFromHash.ts
+++ b/src/hooks/common/useAuthFromHash.ts
@@ -38,5 +38,5 @@ export default function useAuthFromHash({
 
     // 해시 제거
     window.history.replaceState(null, "", window.location.pathname);
-  }, []);
+  }, [redirectIfNicknameNeeded, router]);
 }

--- a/src/hooks/common/useAuthRedirect.ts
+++ b/src/hooks/common/useAuthRedirect.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export const useAuthRedirect = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("access_token");
+
+    if (!token) {
+      router.replace("/login");
+    }
+  }, []);
+};


### PR DESCRIPTION
## ✨ Related Issues
- close #[issue_number]

## 📝 Task Details
- [x]  로그인 complete 페이지로 이동 (유저정보 로컬스토리지 문제 해결)
- [x]  로그인 사용자는 '/'으로 로그인 안되어있으면 '/login' 으로이동
-> <AuthGuard> 컴포넌트를 만들어 RootLayout에서 감싸서 로그인 여부 확인함
-> setTimeout으로 깜빡임 최소화 시킴




## 📂 References

- X버튼 제거
![image](https://github.com/user-attachments/assets/ac0a76c4-6803-4c72-8dff-41f43a3b45d3)


## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
