### PR TITLE
fix: 다이얼로그 title 없어서 생긴 이슈

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-visually-hidden": "^1.2.3",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.9.0",
@@ -1521,6 +1522,28 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-visually-hidden": "^1.2.3",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.9.0",

--- a/src/components/ui/mapDialog.tsx
+++ b/src/components/ui/mapDialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
 import { cn } from "@/lib/utils";
 
@@ -49,6 +50,9 @@ function DialogContent({
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content data-slot="dialog-content" className={className} {...props}>
+        <VisuallyHidden>
+          <DialogTitle>스크린 리더용</DialogTitle>
+        </VisuallyHidden>
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close


### PR DESCRIPTION
## ✨ Related Issues
- close #[issue_number]

## 📝 Task Details

- DialogContent에는 접근성을 보장하기 위해 `DialogTitle`이 필수인데 없어서 접근성 문제 발생하는 오류 해결했습니다.
- 시각적으로는 보이지 않지만 스크린 리더용을 넣기 위해 Radix에서 제공하는 `VisuallyHidden` 컴포넌트로 감쌌습니다. 
- `"@radix-ui/react-visually-hidden": "^1.2.3"` 설치 하였습니다.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
